### PR TITLE
Clarify required comment location in README

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -15,7 +15,7 @@ Currently, this plugin supports the following features that cannot be expressed 
 
 ## Using the Plugin
 
-Add this line to the top of you `pom.xml` right in the beginning of the `<project>` tag:
+Add this line to the top of your `pom.xml` before the `<project>` tag:
 
 ```
 <!-- do_not_remove: published-with-gradle-metadata -->


### PR DESCRIPTION
Hi,

I'm not sure if this is a bug in this plugin or documentation.

I read the instructions in the README to mean that the comment should be placed after the `<project>` tag (where Gradle generates it), but placing it here fails:

```diff
index 7855a58..c51b248 100644
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
  -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
```

```
[ERROR] Failed to execute goal de.jjohannes:gradle-module-metadata-maven-plugin:0.2.0:gmm (default) on project jackson2-api: Execution default of goal de.jjohannes:gradle-module-metadata-maven-plugin:0.2.0:gmm failed: Please add the Gradle Module Metadata marker '<!-- do_not_remove: published-with-gradle-metadata -->' to /home/sghill/gh/sghill/jackson2-api-plugin/target/jackson2-api-2.13.0-999999-SNAPSHOT.pom -> [Help 1]
```

If I move this comment to before `<project>` and any other comments, the build succeeds (and Gradle correctly resolves the module metadata):

```diff
index 7855a58..d29c139 100644
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- do_not_remove: published-with-gradle-metadata -->
 <!--
  ~ Copyright 2015 CloudBees, Inc.
  ~
```